### PR TITLE
Updating to web-greeter ^3.0.0

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -71,7 +71,7 @@ function authentication_complete()
         mainContent.innerHTML = "";
         mainContent.appendChild(welcomeBodyContent);
         // After Welcome Screen Timeout, Start Session
-        setTimeout(function() {lightdm.start_session_sync(lightdm.default_session)}, welcomeScreenTimeout);
+        setTimeout(function() {lightdm.start_session(lightdm.default_session)}, welcomeScreenTimeout);
     }
     else
     {
@@ -105,7 +105,7 @@ function onUserClick(event)
 function setActiveUser(userListing)
 {
     // Get Information For The Selected User Listing
-    let userName = lightdm.users[userListing.getAttribute("data-user-index")].name;
+    let userName = lightdm.users[userListing.getAttribute("data-user-index")].username;
     // If Selected User Already Active, Do Nothing
     if (userName === activeUserName)
     {
@@ -279,6 +279,14 @@ function checkInit()
 
 function init()
 {
+    lightdm.show_prompt?.connect((prompt, type) => {
+      show_prompt(prompt, type);
+    });
+    lightdm.show_message?.connect((msg, type) => {
+      show_message(msg, type);
+    });
+    lightdm.authentication_complete?.connect(() => authentication_complete());
+    lightdm.autologin_timer_expired?.connect(() => autologin_timer_expired());
     // For Each User, Add A Listing In The HTML Document
     let userListDiv = document.getElementById("userListings");
     for (let i = 0; i < lightdm.users.length; i++)


### PR DESCRIPTION
# web-greeter ^3.0.0

Fixes #8

A lots of these kind of themes are outdated, depending of an abandoned project: `lightdm-webkit2-greeter`, later renamed to `web-greeter`, made by Antergos team. However, Antergos left some updates and a little direction to what this project should evolve.

`web-greeter 3.0.0` is now my fork, where I'm trying to develop this project, with some other new features.

You can check my fork [here](https://github.com/JezerM/web-greeter) (web-greeter 3.1.1), and the API docs [here](https://jezerm.github.io/web-greeter/).

## WelcomeXP

@rocheston had some interest to use this theme on [nody-greeter](https://github.com/JezerM/nody-greeter) and [web-greeter](https://github.com/JezerM/web-greeter), so I made some little changes to allow this.

Mergin this PR will mean that this theme won't be usable with `lightdm-webkit2-greeter` at all, but it will allow to have features like battery status, brightness controller, layout selector (which are not included in this PR), and a newer JavaScript engine with Chromium. Also, the README should be changed if this project is moving to these new greeters.

## Changes

- Added signal listeners
- `start_session_sync` deprecated, changed to `start_session`
- `user.name` deprecated, changed to `user.username`