### PR TITLE
Resize profile pictures to fit box

### DIFF
--- a/css/xp.css
+++ b/css/xp.css
@@ -363,6 +363,8 @@ body
 .profile-picture
 {
     width: var(--profile-picture-size);
+    height: var(--profile-picture-size);
+    object-fit: cover;
 }
 
 .user


### PR DESCRIPTION
In the current version, any custom profile picture used that is not in a 1:1 resolution will grow outside of the profile picture box, like so:

![image](https://user-images.githubusercontent.com/75742355/213515985-b4ea7771-e8e0-4b0d-b67a-4fcd02e293f7.png)

This small pull request fixes that by setting the height for the image and cropping it to fit the box (instead of modifying the aspect ratio).

![image](https://user-images.githubusercontent.com/75742355/213516988-90722548-5907-44ef-979b-86e5e26554b0.png)

